### PR TITLE
Corrected SVG attributes for assets for the P_2_3_6 projects.

### DIFF
--- a/01_P/P_2_3_6_01/data/08.svg
+++ b/01_P/P_2_3_6_01/data/08.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 0.001 100 100" enable-background="new 0 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <polygon points="19.499,59.5 19.5,-0.502 39.5,-0.502 39.5,39.5 59.498,39.5 59.498,-0.502 59.5,-0.502 79.5,-0.502 79.5,59.5 
 	19.499,59.5 "/>
 </svg>

--- a/01_P/P_2_3_6_01/data/14.svg
+++ b/01_P/P_2_3_6_01/data/14.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="40 100 100 100" enable-background="new 40 100 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M59.499,99.5h20.002c-0.004-18.927-6.59-36.304-17.574-50C72.911,35.803,79.496,18.426,79.499-0.501h-20
 	c-0.004,13.538-4.46,25.969-12,36.001c-5.382-4.043-11.296-7.412-17.611-10.008C35.873,18.501,39.497,9.427,39.5-0.5h-20
 	c-0.021,11.04-8.96,19.979-20,20v20h0l0,0c12.29,0.005,23.662,3.683,33.161,10.001c-9.499,6.318-20.872,9.995-33.162,9.999v20.002

--- a/01_P/P_2_3_6_02/data/A_08.svg
+++ b/01_P/P_2_3_6_02/data/A_08.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 0.001 100 100" enable-background="new 0 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <polygon points="19.499,59.5 19.5,-0.502 39.5,-0.502 39.5,39.5 59.498,39.5 59.498,-0.502 59.5,-0.502 79.5,-0.502 79.5,59.5 
 	19.499,59.5 "/>
 </svg>

--- a/01_P/P_2_3_6_02/data/A_14.svg
+++ b/01_P/P_2_3_6_02/data/A_14.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="40 100 100 100" enable-background="new 40 100 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M59.499,99.5h20.002c-0.004-18.927-6.59-36.304-17.574-50C72.911,35.803,79.496,18.426,79.499-0.501h-20
 	c-0.004,13.538-4.46,25.969-12,36.001c-5.382-4.043-11.296-7.412-17.611-10.008C35.873,18.501,39.497,9.427,39.5-0.5h-20
 	c-0.021,11.04-8.96,19.979-20,20v20h0l0,0c12.29,0.005,23.662,3.683,33.161,10.001c-9.499,6.318-20.872,9.995-33.162,9.999v20.002

--- a/01_P/P_2_3_6_02/data/B_00.svg
+++ b/01_P/P_2_3_6_02/data/B_00.svg
@@ -2,5 +2,5 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="-1 -1 100 100" enable-background="new -1 -1 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 </svg>

--- a/01_P/P_2_3_6_02/data/B_02.svg
+++ b/01_P/P_2_3_6_02/data/B_02.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="10.001 0 100 100" enable-background="new 10.001 0 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M79.498,89.538c0-0.013,0.002-0.025,0.002-0.038c0-5.523-4.477-10-10-10s-10,4.477-10,10h-0.001l0.002,10l9.979-0.001
 	c0.007,0,0.013,0.001,0.02,0.001s0.013-0.001,0.02-0.001l9.981-0.001L79.498,89.538z M39.5,89.5c0-5.523-4.477-10-10-10
 	s-10,4.477-10,10h0v10l9.981-0.001c0.007,0,0.013,0.001,0.02,0.001s0.013-0.001,0.02-0.001l9.982-0.001L39.5,89.51

--- a/01_P/P_2_3_6_02/data/B_08.svg
+++ b/01_P/P_2_3_6_02/data/B_08.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 0.001 100 100" enable-background="new 0 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M19.499-0.499L19.5,9.49c0,0.003,0,0.006,0,0.01c0,5.523,4.477,10,10,10s10-4.477,10-10v0h0L39.499-0.501L19.499-0.499z
 	 M79.498-0.502l-20,0.002l0.002,10c0,5.522,4.477,10,10,10s10-4.477,10-10c0,0,0-0.001,0-0.001L79.498-0.502z"/>
 </svg>

--- a/01_P/P_2_3_6_02/data/B_09.svg
+++ b/01_P/P_2_3_6_02/data/B_09.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 0.001 100 100" enable-background="new 0 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M89.5,39.5c0.001,0,0.001,0,0.002,0v0l9.999-0.002l-0.002-20l-9.979,0.002c-0.007,0-0.013-0.001-0.02-0.001
 	c-5.523,0-10,4.477-10,10S83.977,39.5,89.5,39.5z M89.499,59.5c-5.523,0.001-9.999,4.477-9.999,10s4.477,10,10,10
 	c0.001,0,0.001,0,0.002,0h9.999l-0.002-20.002L89.499,59.5z M19.499-0.499L19.5,9.49c0,0.003,0,0.006,0,0.01c0,5.523,4.477,10,10,10

--- a/01_P/P_2_3_6_02/data/B_10.svg
+++ b/01_P/P_2_3_6_02/data/B_10.svg
@@ -2,7 +2,6 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="10.001 19.999 100 100" enable-background="new 10.001 19.999 100 100"
-	 xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M19.5,99.5h20V-0.502h-20V99.5z M59.499-0.502V99.5h19.999V-0.502H59.499z"/>
 </svg>

--- a/01_P/P_2_3_6_02/data/B_11.svg
+++ b/01_P/P_2_3_6_02/data/B_11.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 19.999 100 100" enable-background="new 0 19.999 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M79.5,89.5c0-5.523-4.477-10-10-10s-10,4.477-10,10h-0.001l0.002,10l9.979-0.001c0.007,0,0.013,0.001,0.02,0.001
 	s0.013-0.001,0.02-0.001l9.981-0.001l-0.003-9.96C79.498,89.525,79.5,89.513,79.5,89.5z M39.5,89.5c0-5.523-4.477-10-10-10
 	s-10,4.477-10,10h0v10l9.981-0.001c0.007,0,0.013,0.001,0.02,0.001s0.013-0.001,0.02-0.001l9.982-0.001L39.5,89.51

--- a/01_P/P_2_3_6_02/data/B_12.svg
+++ b/01_P/P_2_3_6_02/data/B_12.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 0.001 100 100" enable-background="new 0 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M9.501,59.501L9.501,59.501L9.501,59.501L-0.5,59.502l0.002,20L9.481,79.5c0.007,0,0.013,0.001,0.02,0.001
 	c5.523,0,10-4.478,10-10S15.024,59.501,9.501,59.501z M9.501,19.5L9.501,19.5L9.501,19.5L-0.5,19.501l0.002,20L9.491,39.5
 	c0.003,0,0.006,0,0.01,0c5.523,0,10-4.477,10-10S15.024,19.5,9.501,19.5z M29.5-0.5c-0.006,0-0.013,0.001-0.02,0.001H19.5V9.49

--- a/01_P/P_2_3_6_02/data/B_13.svg
+++ b/01_P/P_2_3_6_02/data/B_13.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0.001 0.001 100 100" enable-background="new 0.001 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M89.5,39.5c0.001,0,0.001,0,0.002,0v0l9.999-0.002l-0.002-20l-9.979,0.002c-0.007,0-0.013-0.001-0.02-0.001
 	c-5.523,0-10,4.477-10,10S83.977,39.5,89.5,39.5z M89.499,59.5c-5.523,0.001-9.999,4.477-9.999,10s4.477,10,10,10
 	c0.001,0,0.001,0,0.002,0h9.999l-0.002-20.002L89.499,59.5z M9.5,59.501c0,0-0.001,0-0.001,0V59.5l-10,0.002l0.002,20L9.48,79.5

--- a/01_P/P_2_3_6_02/data/B_14.svg
+++ b/01_P/P_2_3_6_02/data/B_14.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="10.001 100 100 100" enable-background="new 10.001 100 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M19.499-0.501l0.002,9.99c0,0.003,0,0.006,0,0.01c0,5.523,4.477,10,10,10s10-4.477,10-10v0h0L39.499-0.503L19.499-0.501z
 	 M69.5,19.498c5.523,0,10-4.477,10-10c0,0,0-0.001,0-0.002l-0.002-10l-20,0.002l0.002,10C59.5,15.021,63.977,19.498,69.5,19.498z
 	 M79.5,89.52c0-0.007,0.001-0.013,0.001-0.02c0-5.523-4.478-10-10-10s-10,4.477-10,10c0,0.001,0,0.001,0,0.002H59.5l0.002,9.999

--- a/01_P/P_2_3_6_02/data/B_15.svg
+++ b/01_P/P_2_3_6_02/data/B_15.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0.001 19.999 100 100" enable-background="new 0.001 19.999 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M89.5,39.5c0.001,0,0.001,0,0.002,0v0l9.999-0.002l-0.002-20l-9.979,0.002c-0.007,0-0.013-0.001-0.02-0.001
 	c-5.523,0-10,4.477-10,10S83.977,39.5,89.5,39.5z M89.499,59.5c-5.523,0.001-9.999,4.477-9.999,10s4.477,10,10,10
 	c0.001,0,0.001,0,0.002,0h9.999l-0.002-20.002L89.499,59.5z M19.499-0.499L19.5,9.49c0,0.003,0,0.006,0,0.01c0,5.523,4.477,10,10,10

--- a/01_P/P_2_3_6_02/data/C_04.svg
+++ b/01_P/P_2_3_6_02/data/C_04.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0.001 0 100 100" enable-background="new 0.001 0 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <g>
 	<path d="M49.499,19.499L49.499,19.499c0,0.001,0.001,0.001,0.002,0.001c5.525,0,10.001,4.477,10.001,10s-4.477,10-10.001,10
 		c0,0-0.001,0-0.002,0H-0.5V19.499H49.499 M49.5,59.5c5.525,0,10.001,4.477,10.001,10s-4.477,10-10.001,10

--- a/01_P/P_2_3_6_02/data/C_05.svg
+++ b/01_P/P_2_3_6_02/data/C_05.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0.002 0 100 100" enable-background="new 0.002 0 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <g>
 	<path d="M99.501,59.501v20h-100v-20H99.501 M95.501,63.501h-92v12h92V63.501L95.501,63.501z"/>
 </g>

--- a/01_P/P_2_3_6_02/data/C_06.svg
+++ b/01_P/P_2_3_6_02/data/C_06.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0.001 0 100 100" enable-background="new 0.001 0 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <g>
 	<path d="M-0.5,19.499c44.187,0.006,79.995,35.813,80.002,80H59.498c-0.004-16.601-6.699-31.536-17.571-42.427
 		C31.036,46.199,16.101,39.504-0.5,39.5V19.499 M3.5,23.604v12.02c15.578,0.958,30.101,7.484,41.253,18.618

--- a/01_P/P_2_3_6_02/data/C_07.svg
+++ b/01_P/P_2_3_6_02/data/C_07.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0.001 0 100 100" enable-background="new 0.001 0 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <g>
 	<path d="M99.5,19.5v19.999c-16.602,0.004-31.537,6.7-42.428,17.574C46.197,67.963,39.504,82.898,39.5,99.5h0.002H19.499
 		C19.505,55.313,55.313,19.505,99.5,19.5 M95.5,23.604C56.777,25.628,25.628,56.775,23.604,95.5h12.02

--- a/01_P/P_2_3_6_02/data/C_08.svg
+++ b/01_P/P_2_3_6_02/data/C_08.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 0.001 100 100" enable-background="new 0 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <g>
 	<path d="M79.5-0.501v50.002c-0.001,5.522-4.477,9.999-10,9.999s-9.999-4.477-10-9.999h-0.001V-0.501H79.5 M39.5-0.501v50.002
 		c0,5.522-4.477,9.999-10,9.999s-10-4.479-10-10c0-0.003,0-0.007,0-0.01V-0.501H39.5 M75.5,3.499H63.499v46.002

--- a/01_P/P_2_3_6_02/data/C_09.svg
+++ b/01_P/P_2_3_6_02/data/C_09.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0.001 0.001 100 100" enable-background="new 0.001 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <g>
 	<path d="M79.5-0.501c0.021,11.04,8.959,19.979,19.999,19.999v20C77.402,39.492,59.506,21.595,59.5-0.501H79.5 M39.499-0.5
 		c0.006,16.599,6.699,31.536,17.573,42.425C67.962,52.8,82.898,59.493,99.5,59.499V79.5c-44.188-0.008-79.994-35.813-80-80H39.499

--- a/01_P/P_2_3_6_02/data/C_11.svg
+++ b/01_P/P_2_3_6_02/data/C_11.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0.001 0 100 100" enable-background="new 0.001 0 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <g>
 	<path d="M39.5-0.5c0.005,16.6,6.698,31.535,17.572,42.425c10.892,10.874,25.826,17.568,42.429,17.574V79.5
 		c-44.188-0.009-79.995-35.813-80-80H39.5 M35.623,3.5H23.605c2.023,38.72,33.172,69.868,71.896,71.896V63.376

--- a/01_P/P_2_3_6_02/data/C_12.svg
+++ b/01_P/P_2_3_6_02/data/C_12.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 0.001 100 100" enable-background="new 0 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <g>
 	<path d="M79.499-0.5C79.492,43.686,43.686,79.493-0.5,79.501V59.498c16.599-0.004,31.536-6.698,42.425-17.572
 		C52.8,31.034,59.493,16.1,59.498-0.5H59.5H79.499 M75.395,3.5h-12.02c-0.959,15.578-7.484,30.101-18.619,41.252

--- a/01_P/P_2_3_6_02/data/C_13.svg
+++ b/01_P/P_2_3_6_02/data/C_13.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0.001 0.001 100 100" enable-background="new 0.001 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <g>
 	<path d="M39.5-0.5c0.006,16.6,6.699,31.534,17.575,42.426C67.963,52.8,82.9,59.494,99.5,59.5l-0.002,20.001
 		C55.313,79.493,19.506,43.686,19.5-0.5H39.5 M35.623,3.5H23.604c2.025,38.722,33.173,69.87,71.895,71.896l0.002-12.021

--- a/01_P/P_2_3_6_02/data/C_14.svg
+++ b/01_P/P_2_3_6_02/data/C_14.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 100 100 100" enable-background="new 0 100 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <g>
 	<path d="M79.499-0.5C79.493,43.686,43.686,79.493-0.5,79.501V59.498c16.6-0.004,31.534-6.698,42.426-17.572
 		C52.8,31.034,59.493,16.1,59.498-0.5H59.5H79.499 M75.395,3.5h-12.02c-0.959,15.578-7.484,30.102-18.618,41.252

--- a/01_P/P_2_3_6_02/data/C_15.svg
+++ b/01_P/P_2_3_6_02/data/C_15.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0.001 0.001 100 100" enable-background="new 0.001 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <g>
 	<path d="M99.5,19.5v19.999c-16.602,0.005-31.537,6.698-42.428,17.571C46.197,67.963,39.504,82.896,39.5,99.5h0.002H19.499
 		C19.505,55.313,55.313,19.505,99.5,19.5 M95.5,23.604C56.777,25.627,25.628,56.775,23.604,95.5h12.02

--- a/01_P/P_2_3_6_02/data/E_02.svg
+++ b/01_P/P_2_3_6_02/data/E_02.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="10.001 0 100 100" enable-background="new 10.001 0 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M79.498,89.538c0-0.013,0.002-0.025,0.002-0.038c0-5.523-4.477-10-10-10s-10,4.477-10,10h-0.001l0.002,10l9.979-0.001
 	c0.007,0,0.013,0.001,0.02,0.001s0.013-0.001,0.02-0.001l9.981-0.001L79.498,89.538z M29.5,9.5c-5.523,0-10,4.477-10,10
 	c0,0.01,0.001,0.019,0.001,0.029v79.966h20V19.497H39.5C39.498,13.976,35.022,9.5,29.5,9.5z"/>

--- a/01_P/P_2_3_6_02/data/E_05.svg
+++ b/01_P/P_2_3_6_02/data/E_05.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0.001 0 100 100" enable-background="new 0.001 0 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M99.499,59.498l-10,0.002c-5.523,0.001-9.999,4.477-9.999,10s4.477,10,10,10c0.001,0,0.001,0,0.002,0h9.999L99.499,59.498z
 	 M9.5,59.5L9.5,59.5L9.5,59.5l-10.001,0.001l0.002,20l9.979-0.002c0.007,0,0.013,0.001,0.02,0.001c5.523,0,10-4.477,10-10
 	S15.023,59.5,9.5,59.5z M99.498,19.5H-0.5v20h100L99.498,19.5z"/>

--- a/01_P/P_2_3_6_02/data/E_06.svg
+++ b/01_P/P_2_3_6_02/data/E_06.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="10.001 0 100 100" enable-background="new 10.001 0 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M-0.5,29.5c0,0.005,0.001,0.01,0.001,0.015l0.001,9.987L9.49,39.5c0.003,0,0.006,0,0.01,0c5.523,0,10-4.477,10-10
 	s-4.477-10-10-10v0L-0.5,19.501l0.001,9.984C-0.499,29.49-0.5,29.495-0.5,29.5z M69.5,19.5c-5.522,0-9.998,4.476-10,9.998h-0.003
 	V99.5h20.001V29.539c0-0.013,0.002-0.025,0.002-0.039C79.5,23.977,75.023,19.5,69.5,19.5z M-0.5,59.499v19.999

--- a/01_P/P_2_3_6_02/data/E_08.svg
+++ b/01_P/P_2_3_6_02/data/E_08.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 0.001 100 100" enable-background="new 0 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M59.502-0.498V79.46c0,0.014-0.002,0.026-0.002,0.039c0,5.522,4.477,10,10,10s9.999-4.477,10-9.999h0.002V-0.498H59.502z
 	 M19.499-0.499L19.5,9.49c0,0.003,0,0.006,0,0.01c0,5.523,4.477,10,10,10s10-4.477,10-10v0h0L39.499-0.501L19.499-0.499z"/>
 </svg>

--- a/01_P/P_2_3_6_02/data/E_10.svg
+++ b/01_P/P_2_3_6_02/data/E_10.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 0.001 100 100" enable-background="new 0 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M19.5,99.5h20V-0.502h-20V99.5z M79.498,89.538c0-0.013,0.002-0.025,0.002-0.038c0-5.523-4.477-10-10-10s-10,4.477-10,10
 	h-0.001l0.002,10l9.979-0.001c0.007,0,0.013,0.001,0.02,0.001s0.013-0.001,0.02-0.001l9.981-0.001L79.498,89.538z M69.5,19.499
 	c5.523,0,10-4.477,10-10v0l-0.002-10l-20,0.002l0.002,10C59.501,15.023,63.977,19.499,69.5,19.499z"/>

--- a/01_P/P_2_3_6_02/data/E_12.svg
+++ b/01_P/P_2_3_6_02/data/E_12.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 0.001 100 100" enable-background="new 0 0.001 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M79.498-0.502l-20,0.002l0.002,10c0,5.522,4.477,10,10,10s10-4.477,10-10c0,0,0-0.001,0-0.001L79.498-0.502z M69.502,59.5
 	v-0.002H-0.5v20h69.961c0.014,0,0.026,0.002,0.039,0.002c5.523,0,10-4.477,10-10C79.5,63.978,75.024,59.501,69.502,59.5z M39.5-0.5
 	h-20c-0.021,11.04-8.96,19.979-20,20v20C21.594,39.493,39.493,21.594,39.5-0.5z"/>

--- a/01_P/P_2_3_6_02/data/E_14.svg
+++ b/01_P/P_2_3_6_02/data/E_14.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="40 100 100 100" enable-background="new 40 100 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M59.501-0.5v100h20v-100H59.501z M-0.501,19.5v20c22.094-0.006,39.994-17.906,40-40h-20
 	C19.478,10.541,10.539,19.48-0.501,19.5z M-0.501,59.498V79.5c11.04,0.019,19.979,8.957,20,19.999h20
 	C39.492,77.404,21.594,59.506-0.501,59.498z"/>

--- a/01_P/P_2_3_6_02/data/E_15.svg
+++ b/01_P/P_2_3_6_02/data/E_15.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="0 100 100 100" enable-background="new 0 100 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M59.499,99.5h19.999c0.021-11.042,8.96-19.98,20.002-20.002V59.499C77.403,59.505,59.505,77.403,59.499,99.5z M-0.5,59.499
 	v19.999c11.04,0.021,19.979,8.96,20,20.002h20C39.493,77.403,21.595,59.505-0.5,59.499z M-0.5,19.5v20
 	c22.094-0.006,39.994-17.906,40-40h-20C19.479,10.54,10.54,19.479-0.5,19.5z M79.498-0.5H59.499

--- a/01_P/P_2_3_6_02/data/J_10.svg
+++ b/01_P/P_2_3_6_02/data/J_10.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="100px" height="100px" viewBox="19.999 0 100 100" enable-background="new 19.999 0 100 100" xml:space="preserve">
+	 width="100px" height="100px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
 <path d="M29.501,9.499l10,10L49.5,9.5l-10-10l0,0h-20L29.501,9.499L29.501,9.499z M29.502,29.498L29.502,29.498l-10,9.999
 	l9.999,9.999l9.999-9.999l0.001,0.001l10-10l-10-10L29.502,29.498z M69.499,9.499L69.499,9.499L79.5-0.5H59.502L59.5-0.501l-10,10
 	l10,10L69.499,9.499z M69.5,29.5L69.5,29.5l-9.999-10l-10,10l10,10L59.5,39.5l10,10l10-10L69.5,29.5z M39.501,39.5l-20,20l10,10


### PR DESCRIPTION
Corrected the viewBox and enable-background attributes for some of the SVGs in the P_2_3_6 projects. Some of the tiles were being placed in incorrect postions, as some of the viewBox and enable-background attributes on the SVG files were incorrect and not "0 0 100 100".
