### PR TITLE
03_A: Compatibility fixes for Processing 3.2.3

### DIFF
--- a/03_A/Cover/Cover.pde
+++ b/03_A/Cover/Cover.pde
@@ -1,6 +1,6 @@
 // Cover.pde
 // ImageRibbon.pde, Tag.pde
-// 
+//
 // Generative Gestaltung, ISBN: 978-3-87439-759-9
 // First Edition, Hermann Schmidt, Mainz, 2009
 // Hartmut Bohnacker, Benedikt Groß, Julia Laub, Claudius Lazzeroni
@@ -132,7 +132,11 @@ float tagBlockGapRatio = 0.25;
 
 
 void setup() {
-  size(1310*qf, 822*qf); 
+  // Default values are:
+  // width: 1310;
+  // height: 822;
+  // Multiply this values by qf to get the correct resolution.
+  size(1310, 822);
   frameRate(4);
 
   smooth();
@@ -310,16 +314,16 @@ void setup() {
   // ------ load files ------
   imageCount = 0;
 
-  File dir = new File(sketchPath, "data/images");
+  File dir = new File(sketchPath(), "data/images");
 
   if (dir.isDirectory()) {
     String[] contents = dir.list();
-    images = new PImage[contents.length]; 
+    images = new PImage[contents.length];
     //for (int i = 15 ; i < 60; i++) {
     for (int i = 0 ; i < contents.length; i++) {
       if (contents[i].charAt(0) == '.') continue;
       else if (contents[i].toLowerCase().endsWith(".png") || contents[i].toLowerCase().endsWith(".jpg")) {
-        File childFile = new File(dir, contents[i]);        
+        File childFile = new File(dir, contents[i]);
         images[imageCount] = loadImage(childFile.getPath());
         println(imageCount+" - "+contents[i]);
         imageCount++;

--- a/03_A/Cover/Cover.pde
+++ b/03_A/Cover/Cover.pde
@@ -129,14 +129,12 @@ float tagBlockFactor = 1;
 float tagBlockGapRatio = 0.25;
 
 
+void settings() {
+    size(1310 * qf, 822 * qf);
+}
 
 
 void setup() {
-  // Default values are:
-  // width: 1310;
-  // height: 822;
-  // Multiply this values by qf to get the correct resolution.
-  size(1310, 822);
   frameRate(4);
 
   smooth();

--- a/03_A/Force_Directed_Tags/Force_Directed_Tags.pde
+++ b/03_A/Force_Directed_Tags/Force_Directed_Tags.pde
@@ -99,8 +99,12 @@ int[] bookParts = new int[0];
 PFont font;
 
 
+void settings() {
+  size((2*205)*qf, 285*qf);
+}
+
+
 void setup() {
-  size((2*205)*qf, 285*qf); 
   background(255);
   smooth();
   noStroke();


### PR DESCRIPTION
Small fixes to make 03_A/Cover work on Processing 3.2.3:
- Moved `size(…)` from `setup` to the `settings` method.
- Changed `sketchPath`, which doesn't seem to exist anymore, to `sketchPath()`.